### PR TITLE
GHA: coverallsapp/github-action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,9 +38,10 @@ jobs:
         run: npm run test:coverage:report
 
       - name: Send coverage report
-        run: npx coveralls < coverage/lcov.info
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        uses: coverallsapp/github-action@v2
+        with:
+          file: ./coverage/lcov.info
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Clean after tests
         run: npm run clean


### PR DESCRIPTION
* Replaced the manual `npx coveralls` command and direct use of `COVERALLS_REPO_TOKEN` with the official `coverallsapp/github-action@v2`, using the built-in `GITHUB_TOKEN` for authentication and specifying the coverage report file. (.github/workflows/ci.yaml)